### PR TITLE
Use Contributor Covenant for Code of Conduct

### DIFF
--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -1,57 +1,129 @@
-## Shorter version
 
-Ruby New Zealand is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
+# Contributor Covenant Code of Conduct
 
-This code of conduct applies to all Ruby New Zealand spaces, including our associated mailing lists, events, Slack group, and projects; both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Ruby New Zealand committee.
+## Our Pledge
 
-Some Ruby New Zealand spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
-## Longer version
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-Ruby New Zealand is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+## Our Standards
 
-This code of conduct applies to all Ruby New Zealand spaces, including our associated mailing lists, events, Slack group, and projects; both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Ruby New Zealand committee.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-Some Ruby New Zealand spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-Harassment includes:
+Examples of unacceptable behavior include:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion.
-* Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
-* Deliberate misgendering or use of ‘dead’ or rejected names.
-* Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate.
-* Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
-* Threats of violence.
-* Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.
-* Deliberate intimidation.
-* Stalking or following.
-* Harassing photography or recording, including logging online activity for harassment purposes.
-* Sustained disruption of discussion.
-* Unwelcome sexual attention.
-* Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
-* Continued one-on-one communication after requests to cease.
-* Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse.
-* Publication of non-harassing private communication. 
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-Ruby New Zealand prioritises marginalised people’s safety over privileged people’s comfort. Ruby New Zealand committee will not act on complaints regarding:
+## Enforcement Responsibilities
 
-* ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
-* Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
-* Communicating in a ‘tone’ you don’t find congenial
-* Criticising racist, sexist, cissexist, or otherwise oppressive behavior or assumptions 
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-## Reporting
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
-If you are being harassed by a member of Ruby New Zealand, notice that someone else is being harassed, or have any other concerns, please contact the Ruby New Zealand committee at president@ruby.org.nz or private message one of the committee members on Slack. The current committee member list can be found [here](http://ruby.nz/). If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+## Scope
 
-This code of conduct applies to Ruby New Zealand spaces, but if you are being harassed by a member of Ruby New Zealand outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Ruby New Zealand members, especially the committee, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from Ruby New Zealand based on their past behavior, including behavior outside Ruby New Zealand spaces and behavior towards people who are not in Ruby New Zealand.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
-In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+## Enforcement
 
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Ruby New Zealand members or the general public. We will not name harassment victims without their affirmative consent.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
 
-## Consequences
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
-Participants asked to stop any harassing behavior are expected to comply immediately.
+## Enforcement Guidelines
 
-If a participant engages in harassing behavior, Ruby New Zealand committee may take any action they deem appropriate, up to and including expulsion from all Ruby New Zealand spaces and identification of the participant as a harasser to other Ruby New Zealand members or the general public. 
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -60,8 +60,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the [community leaders responsible for enforcement](https://ruby.nz/#slack-moderators).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
As agreed at the 2020 AGM, use the Contributor Covenant 2.0 for the Ruby NZ Code of Conduct